### PR TITLE
feat: celebrate monthly anniversaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
             <div><span id="minutes">0</span><small>นาที</small></div>
             <div><span id="seconds">0</span><small>วินาที</small></div>
         </div>
+        <p id="elapsed"></p>
+        <p id="next-date"></p>
     </section>
 
     <!-- เรื่องของเรา -->
@@ -75,8 +77,8 @@
         <h2>เหตุผลที่เมฆชอบเบียร์</h2>
         <p>อยู่ด้วยแล้วสบายใจ ถึงจะชอบงอแงแต่ก็น่ารักเสมอ ขอบคุณที่เดินมาด้วยกันนะ</p>
     </section>
-
     <!-- JS -->
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,8 @@
     hours: document.getElementById('hours'),
     minutes: document.getElementById('minutes'),
     seconds: document.getElementById('seconds'),
+    elapsed: document.getElementById('elapsed'),
+    nextDate: document.getElementById('next-date'),
     modal: document.getElementById('modal'),
     modalImg: document.getElementById('modal-img'),
     closeBtn: document.querySelector('.close'),
@@ -15,19 +17,32 @@
 
   const getNextAnniversary = () => {
     const now = new Date();
-    const next = new Date(
-      now.getFullYear(),
-      startDate.getMonth(),
-      startDate.getDate()
-    );
-    if (next < now) {
-      next.setFullYear(next.getFullYear() + 1);
+    const next = new Date(now.getFullYear(), now.getMonth(), startDate.getDate());
+    if (next <= now) {
+      next.setMonth(next.getMonth() + 1);
     }
-    return next.getTime();
+    return next;
   };
 
+  const updateElapsed = () => {
+    const now = new Date();
+    let years = now.getFullYear() - startDate.getFullYear();
+    let months = now.getMonth() - startDate.getMonth();
+    if (now.getDate() < startDate.getDate()) {
+      months--;
+    }
+    if (months < 0) {
+      years--;
+      months += 12;
+    }
+    elements.elapsed.textContent = `เราอยู่ด้วยกันมาแล้ว ${years} ปี ${months} เดือน`;
+  };
+
+  let hasFired = false;
+
   const updateCountdown = () => {
-    const distance = getNextAnniversary() - Date.now();
+    const next = getNextAnniversary();
+    const distance = next.getTime() - Date.now();
     const time = {
       days: Math.floor(distance / (1000 * 60 * 60 * 24)),
       hours: Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)),
@@ -38,10 +53,45 @@
     Object.entries(time).forEach(([key, value]) => {
       elements[key].textContent = value < 0 ? 0 : value;
     });
+
+    const nextStr = next.toLocaleDateString('th-TH', { year: 'numeric', month: 'long', day: 'numeric' });
+    elements.nextDate.textContent = `ครบรอบครั้งต่อไป: ${nextStr}`;
+
+    if (distance <= 0) {
+      checkToday();
+    }
+  };
+
+  const triggerFireworks = big => {
+    if (typeof confetti !== 'function') return;
+    const duration = big ? 5000 : 2000;
+    const end = Date.now() + duration;
+    (function frame() {
+      confetti({
+        particleCount: big ? 120 : 60,
+        spread: 60,
+        origin: { y: 0 },
+        gravity: big ? 0.8 : 1.2
+      });
+      if (Date.now() < end) {
+        requestAnimationFrame(frame);
+      }
+    })();
+  };
+
+  const checkToday = () => {
+    const now = new Date();
+    if (!hasFired && now.getDate() === startDate.getDate()) {
+      const big = now.getMonth() === startDate.getMonth();
+      triggerFireworks(big);
+      hasFired = true;
+    }
   };
 
   setInterval(updateCountdown, 1000);
   updateCountdown();
+  updateElapsed();
+  checkToday();
 
   const observer = new IntersectionObserver(
     entries => {


### PR DESCRIPTION
## Summary
- display years and months together along with next monthly anniversary date
- trigger falling confetti on the 19th, with extra bursts for yearly anniversaries

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689969d5b148832f8fdd356e934b7aae